### PR TITLE
fixes three typos in infix tutorial.

### DIFF
--- a/docs/expressions/exceptions.md
+++ b/docs/expressions/exceptions.md
@@ -76,7 +76,7 @@ The callE() will always be excuted. If callB() returns true then the sequence ex
 
 __Do I have to have an else error handler to have a then block?__ No. You can have a try-then block without an else if you like.
 
-__Will my then block really always be executed, even if I return inside the try?__ Yes, your `then` expression will __always__ be executed when the try block is complete. The only way it won't be is if the try never completes (due to an inifinite loop), the machine is powered off or the process is killed (and then, maybe).
+__Will my then block really always be executed, even if I return inside the try?__ Yes, your `then` expression will __always__ be executed when the try block is complete. The only way it won't be is if the try never completes (due to an infinite loop), the machine is powered off or the process is killed (and then, maybe).
 
 # Language constructs that can raise errors
 

--- a/docs/expressions/infix-ops.md
+++ b/docs/expressions/infix-ops.md
@@ -5,7 +5,7 @@ Infix operators take two operands and are written between those operands. Arithm
 a < b
 ```
 
-Pony has pretty much the same set of infix operators as other langauges.
+Pony has pretty much the same set of infix operators as other languages.
 
 # Precedence
 

--- a/docs/expressions/infix-ops.md
+++ b/docs/expressions/infix-ops.md
@@ -19,7 +19,7 @@ We will get a value of 9 if we evaluate the addition first and 7 if we evaluate 
 
 The problem with this is that the programmer has to remember the order and people aren't very good at things like that. Most people will remember to do multiplication before addition, but what about left bit shifting versus bitwise and? Sometimes people misremember (or guess wrong) and that leads to bugs. Worse, those bugs are often very hard to spot.
 
-Pony takes a different approach and outlaws infix precedence. Any expression where more than one infix operator is used __must__ use parentheses to remove the ambiguity. If you failure to do this the compiler will complain.
+Pony takes a different approach and outlaws infix precedence. Any expression where more than one infix operator is used __must__ use parentheses to remove the ambiguity. If you fail to do this the compiler will complain.
 
 This means that the example above is illegal in Pony and should be rewritten as:
 
@@ -111,7 +111,7 @@ This is a special feature built into the compiler, it cannot be used with operat
 
 # Unary operators
 
-The unary operators are handled in the same manor, but with only one operand. For example the following expressions are equivalent:
+The unary operators are handled in the same manner, but with only one operand. For example the following expressions are equivalent:
 
 ```pony
 -x


### PR DESCRIPTION
failure -> fail, manor -> manner, langauge -> language.