### PR TITLE
correction of some typos

### DIFF
--- a/docs/c-ffi/calling-c.md
+++ b/docs/c-ffi/calling-c.md
@@ -61,7 +61,7 @@ Pony classes corresponds directly to pointers to the class in C.
 
 For C pointers to simple types, such as U64, the Pony `Pointer[]` polymorphic type should be used, with a `tag` reference capability. `Pointer[U8] tag` should be used for void*. This can be seen in our SSL_CTX_ctrl example above.
 
-To pass pointers to values to C an ampersand (&) can be used, just like taking an address in C. This is done in the standard library to pass the address of a U64 to an FFI functions that takes a uint64_t* as an out parameter:
+To pass pointers to values to C an ampersand (&) can be used, just like taking an address in C. This is done in the standard library to pass the address of a U64 to an FFI function that takes a uint64_t* as an out parameter:
 
 ```pony
 var len = U64(0)

--- a/docs/capabilities/arrow-types.md
+++ b/docs/capabilities/arrow-types.md
@@ -4,7 +4,7 @@ When that happens, we can write a __viewpoint adapted type__, which we call an _
 
 # Using `this->` as a viewpoint
 
-A function with a `box` receiver can be called with a `ref` receiver or a `val` receiver as well, since those are both subtypes of `box`. Sometimes, we want to be able to talk about a type takes this into account. For example:
+A function with a `box` receiver can be called with a `ref` receiver or a `val` receiver as well, since those are both subtypes of `box`. Sometimes, we want to be able to talk about a type to take this into account. For example:
 
 ```pony
 class Wombat

--- a/docs/capabilities/object-capabilities.md
+++ b/docs/capabilities/object-capabilities.md
@@ -32,6 +32,6 @@ There's a great paper on how the object-capability model works, and it's pretty 
 
 The object-capability model on its own does not address concurrency. It makes clear _what_ will happen if there is simultaneous access to an object, but it does not proscribe a single method of controlling this.
 
-Combining capabilities with the actor-model is a good start, and has been done before in languages such as [E](http://erights.org/) and Joulle.
+Combining capabilities with the actor-model is a good start, and has been done before in languages such as [E](http://erights.org/) and Joule.
 
 Pony does this and also uses a system of _reference capabilities_ in the type system.

--- a/docs/expressions/control-structures.md
+++ b/docs/expressions/control-structures.md
@@ -22,7 +22,7 @@ else
 end
 ```
 
-Often you want to test more than condition in one go, giving you more than two possible outcomes. You can nest `if` statements, but this quickly gets ugly:
+Often you want to test more than one condition in one go, giving you more than two possible outcomes. You can nest `if` statements, but this quickly gets ugly:
 
 ```pony
 if a == b then
@@ -123,7 +123,7 @@ __So is this like an else block on a while loop in Python?__ No, this is very di
 
 ## Break
 
-Sometimes you want to stop part-way through a loop and give up altogether. Pony has the `break` keyword for this and it is very similar to its counterpart in langauges like C++, C# and Python.
+Sometimes you want to stop part-way through a loop and give up altogether. Pony has the `break` keyword for this and it is very similar to its counterpart in languages like C++, C# and Python.
 
 `break` immediately exits from the innermost loop it's in. Since the loop has to return a value `break` can take an expression. This is optional and if it's missed out a value of `None` is returned.
 
@@ -152,7 +152,7 @@ __Can I break out of multiple, nested loops like the Java labelled break?__ No, 
 
 ## Continue
 
-Sometimes you want to stop part-way through one loop iteration and move onto the next. Like other languages Pony uses the `continue` keywords for this.
+Sometimes you want to stop part-way through one loop iteration and move onto the next. Like other languages Pony uses the `continue` keyword for this.
 
 `continue` stops executing the current iteration of the innermost loop it's in and evaluates the condition ready for the next iteration.
 

--- a/docs/expressions/exceptions.md
+++ b/docs/expressions/exceptions.md
@@ -18,7 +18,7 @@ In the above code callA() will always be executed and so will callB(). If the re
 
 However, if callB() returns false, then an error will be raised. At this point execution will stop and the nearest enclosing error handler will be found and executed. In this example that is our else block and so callD() will be executed.
 
-In either case execution will then carry on will whatever code comes after the try `end`.
+In either case execution will then carry on with whatever code comes after the try `end`.
 
 __Do I have to provide an error handler?__ No. The try block will handle any errors regardless. If you don't provide an error handler then no error handling action will be taken - execution will simply continue after the try expression.
 

--- a/docs/expressions/infix-ops.md
+++ b/docs/expressions/infix-ops.md
@@ -101,7 +101,7 @@ xor      | op_xor() | Xor, both bitwise and logical
 
 # Short circuiting
 
-The `and` and `or` operators use __short circuiting__ when used with Bool operators. This means that the first operand is always evaluated, but the second is only evaluated if it can affect the result.
+The `and` and `or` operators use __short circuiting__ when used with Bool variables. This means that the first operand is always evaluated, but the second is only evaluated if it can affect the result.
 
 For `and`, if the first operand is __false__ then the second operand is not evaluated, since it cannot affect the result.
 

--- a/docs/expressions/methods.md
+++ b/docs/expressions/methods.md
@@ -64,7 +64,7 @@ As in many other languages, methods in Pony are called by providing the argument
 
 ```pony
 class Foo
-  fun hello(name: string): String =>
+  fun hello(name: String): String =>
     "hello " + name
 
   fun f() =>
@@ -148,9 +148,9 @@ class Coord
 
 class Bar
   fun f() =>
-    var a: Foo = Coord.create()     // Contains (0, 0)
-	var b: Foo = Coord.create(3)    // Contains (3, 0)
-	var b: Foo = Coord.create(3, 4) // Contains (3, 4)
+    var a: Coord = Coord.create()     // Contains (0, 0)
+	var b: Coord = Coord.create(3)    // Contains (3, 0)
+	var b: Coord = Coord.create(3, 4) // Contains (3, 4)
 ```
 
 __Do I have to provide default values for all of my arguments?__ No, you can provide defaults for as many, or as few, as you like.
@@ -172,7 +172,7 @@ class Coord
 
 class Bar
   fun f() =>
-    var a: Foo = Coord.create(where y = 4, x = 3)
+    var a: Coord = Coord.create(where y = 4, x = 3)
 ```
 
 __Should I specify `where` for each named argument?__ No. There must only be one `where` in each method call.

--- a/docs/expressions/sugar.md
+++ b/docs/expressions/sugar.md
@@ -82,7 +82,7 @@ var foo = Foo.create().apply()
 var bar = Bar.create().apply(x, 37 where crash = false)
 ```
 
-__What if the create has default arguments? Does I get the combined create-apply sugar if I want to use the defaults?__ The combined create-apply sugar can only be used when the create constructor has no arguments. If there are default arguments then this sugar cannot be used.
+__What if the create has default arguments? Do I get the combined create-apply sugar if I want to use the defaults?__ The combined create-apply sugar can only be used when the create constructor has no arguments. If there are default arguments then this sugar cannot be used.
 
 # Update
 

--- a/docs/expressions/variables.md
+++ b/docs/expressions/variables.md
@@ -1,4 +1,4 @@
-Like most other programming language Pony allows you to store data in variables. There are a few different kinds of variables which have different lifetimes and are used for slightly different purposes.
+Like most other programming languages Pony allows you to store data in variables. There are a few different kinds of variables which have different lifetimes and are used for slightly different purposes.
 
 # Local variables
 
@@ -59,7 +59,7 @@ You never have to declare variables as `let`, but if you know you're never going
 
 # Fields
 
-In Pony, fields are variables that live within objects. They work like fields in other object-oriented langauges.
+In Pony, fields are variables that live within objects. They work like fields in other object-oriented languages.
 
 Fields have the same lifetime as the object they're in, rather than being scoped. They are set up by the object constructor and disposed of along with the object.
 

--- a/docs/types/classes.md
+++ b/docs/types/classes.md
@@ -45,7 +45,7 @@ class Wombat
 
   new hungry(name': String, hunger': U64) =>
     name = name'
-    _hunger_level = hunger
+    _hunger_level = hunger'
 ```
 
 Here, we have two constructors, one that creates a `Wombat` that isn't hungry, and another that creates a `Wombat` that might be hungry or might not.
@@ -140,7 +140,7 @@ a = b = a
 
 # What about inheritance?
 
-In some object-oriented languages, a type can _inherit_ from another type, like how in Java something can __extend__ something else. Pony doesn't do that. Instead, Pony prefers _composition_ to _inheritence_. In other words, instead of getting code reuse by saying something __is__ something else, you get it by saying something __has__ something else.
+In some object-oriented languages, a type can _inherit_ from another type, like how in Java something can __extend__ something else. Pony doesn't do that. Instead, Pony prefers _composition_ to _inheritance_. In other words, instead of getting code reuse by saying something __is__ something else, you get it by saying something __has__ something else.
 
 On the other hand, Pony has a powerful __trait__ system (similar to Java 8 interfaces that can have default implementations) and a powerful __interface__ system (similar to Go interfaces, i.e. structurally typed).
 

--- a/docs/types/traits-and-interfaces.md
+++ b/docs/types/traits-and-interfaces.md
@@ -4,7 +4,7 @@ There are two kinds of __subtyping__ in programming languages: __nominal__ and _
 
 # Nominal subtyping
 
-This kind of subytping is called __nominal__ because it is all about __names__.
+This kind of subtyping is called __nominal__ because it is all about __names__.
 
 If you've done object-oriented programming before, you may have seen a lot of discussion about _single inheritance_, _multiple inheritance_, _mixins_, _traits_, and similar concepts. These are all examples of __nominal subtyping__.
 
@@ -38,7 +38,7 @@ __Wait, why not?__ Because `Larry` doesn't say it `is Named`. Remember, traits a
 
 # Structural subtyping
 
-There's another kind of subtyping, where the name doesn't matter. It's called __strutural subtyping__, which means that it's all about how a type is built, and nothing to do with names.
+There's another kind of subtyping, where the name doesn't matter. It's called __structural subtyping__, which means that it's all about how a type is built, and nothing to do with names.
 
 A concrete type is a member of a structural category if it happens to have all the needed elements, no matter what it happens to be called.
 


### PR DESCRIPTION
Hi Pony creators,

I have worked through the tutorial which is really a nice read, and from what I have seen and understood I like Pony very much, congratulations! Along the way I have collected the typos I saw, most of them are trivial text typos, a few in code sections also: I have corrected them all in this pull request.

I also have a few suggestions which I list here:

1) Section:  Actors - Behaviors
why is amount.min used in this code:
	be eat(amount: U64) =>
    	_hunger_level = _hunger_level - amount.min(_hunger_level)
amount.min has not been introduced yet

Perhaps replace it by:    	_hunger_level = _hunger_level - amount
Which is easier to understand at this level in the tutorial.

2) Section: Control structures - Loops
while count <=  do10 do
  env.out.print(count)
  count = count + 1
end
<-- In this code do has not the keyword colour as have while and end

3) Section: Capabilities – Guarantees 
If an actor has a val variable, no other variable can be used by any actor to write to that object.
Shouldn’t this be:
If an actor has a val variable, no variable can be used by any actor to write to that object.
(leave out other)
By saying no other variable it is suggested that it can be written to with this val variable, if I understand correctly.

4) Section: Aliasing – Ephemeral types
In Pony, every expression has a type. So what's the type of consume a?
	<-- no typo here, but I am pretty sure that the consume keyword has not been talked about until now.
(perhaps a reference to the following section is sufficient)

5) Section: Recovering capabilities – How does this work?
Inside the recover expression, your code only has access to sendable values from the enclosing lexical scope.
	<-- no typo here, but it was not clear to me what sendable means, please explain

Keep up the great work, I will be following Pony with great interest!

Ivo


Signed-off-by: Ivo Balbaert <ivo.balbaert@telenet.be>