### PR TITLE
Editors update: emacs and vim

### DIFF
--- a/docs/getting-started/what-you-need-to-start.md
+++ b/docs/getting-started/what-you-need-to-start.md
@@ -6,6 +6,7 @@ While you can write code using any editor, it's nice to use one with some suppor
 
 * [Sublime Text](http://www.sublimetext.com/). There's a [Pony Language](https://packagecontrol.io/packages/Pony%20Language) package.
 * [Atom](https://atom.io/). There's a [language-pony](https://atom.io/packages/language-pony) package.
+* [Emacs](https://www.gnu.org/software/emacs/emacs.html). There's a [ponylang-mode](https://github.com/abingham/ponylang-mode).
 * Vim. A Pony package is pending.
 * [Microsoft Visual Studio](http://www.visualstudio.com/). A Pony plugin is pending.
 

--- a/docs/getting-started/what-you-need-to-start.md
+++ b/docs/getting-started/what-you-need-to-start.md
@@ -7,7 +7,7 @@ While you can write code using any editor, it's nice to use one with some suppor
 * [Sublime Text](http://www.sublimetext.com/). There's a [Pony Language](https://packagecontrol.io/packages/Pony%20Language) package.
 * [Atom](https://atom.io/). There's a [language-pony](https://atom.io/packages/language-pony) package.
 * [Emacs](https://www.gnu.org/software/emacs/emacs.html). There's a [ponylang-mode](https://github.com/abingham/ponylang-mode).
-* Vim. A Pony package is pending.
+* [Vim](http://www.vim.org). A Pony package is pending.
 * [Microsoft Visual Studio](http://www.visualstudio.com/). A Pony plugin is pending.
 
 If you have a favourite editor that isn't supported, we'd love to help you build a Pony package for it.


### PR DESCRIPTION
Hi.
I saw that emacs was not present in the list of editors supporting Pony, despite the fact that a [major mode](http://www.vim.org) was already been already published, so I added it.

Also, all the editors had a link to their official websites, but vim. I fixed that.

Cheers!